### PR TITLE
Fixed syntax highlighting for %var%

### DIFF
--- a/Packages/Autohotkey/Autohotkey.tmLanguage
+++ b/Packages/Autohotkey/Autohotkey.tmLanguage
@@ -1,4 +1,3 @@
-
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE plist PUBLIC "-//Apple Computer//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
@@ -131,7 +130,7 @@
             <key>name</key>
             <string>storage.type.primitive.array.java</string>
             <key>match</key>
-            <string>(%)(([^%]|%%)*)(%)</string>
+            <string>(%)(([^%,]|%%)*)(%)</string>
         </dict>
 
 


### PR DESCRIPTION
Lines like `Gui, Font, % options, % font_name` (forced expressions) is highlighted incorrect because the comma is ignored.
